### PR TITLE
Use errno for cross-platform support

### DIFF
--- a/single.py
+++ b/single.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import sys,os
+import sys,os, errno
 
 doc="""Usage: {me} [options] -c command args..
 
@@ -68,7 +68,8 @@ class Lock(object):
         try:
             flock(self.lock_fh, LOCK_EX|LOCK_NB)
         except IOError, e:
-            if e.args[0]==11: # Resource temporarily unavailable
+
+            if e.args[0]==errno.EAGAIN: # Resource temporarily unavailable
                 return False
             else:
                 raise


### PR DESCRIPTION
Error numbers can differ between POSIX OSs. This PR attempts to improve cross-platform support by using errno to resolve error codes to symbols. It has been tested on both Mac 10.12 and CentOS 7.

It was inspired by the following traceback seen on a Mac:
```
Traceback (most recent call last):
  File "./single.py", line 216, in <module>
    main()
  File "./single.py", line 208, in main
    status=do_status(lock_file)
  File "./single.py", line 139, in do_status
    gotit,pid=lock.lock_pid()
  File "./single.py", line 89, in lock_pid
    if self.get_lock():
  File "./single.py", line 68, in get_lock
    flock(self.lock_fh, LOCK_EX|LOCK_NB)
IOError: [Errno 35] Resource temporarily unavailable
```